### PR TITLE
refactor: limita busca de pokémons às três primeiras gerações

### DIFF
--- a/assets/src/script.js
+++ b/assets/src/script.js
@@ -97,7 +97,7 @@ let arrPokemons = [];
 let isLoading = false;
 const getPokemons = async () => {
   try {
-    const url = `https://pokeapi.co/api/v2/pokemon?limit=1500&offset=0`;
+    const url = `https://pokeapi.co/api/v2/pokemon?limit=386&offset=0`;
     const response = await fetch(url);
     const data = await response.json();
     arrPokemons = data.results;


### PR DESCRIPTION
- Reduz o limite da API de 1500 para 386 (Kanto, Johto e Hoenn)
- Melhora a performance e a experiência do usuário
- Aumenta a estabilidade do carregamento em produção (Vercel e GitHub Pages)