### PR TITLE
feat: adiciona proxy via rewrites da Vercel para consumo da PokeAPI

### DIFF
--- a/assets/src/script.js
+++ b/assets/src/script.js
@@ -97,7 +97,13 @@ let arrPokemons = [];
 let isLoading = false;
 const getPokemons = async () => {
   try {
-    const url = `https://pokeapi.co/api/v2/pokemon?limit=386&offset=0`;
+    const isLocalhost =
+      window.location.hostname === "localhost" ||
+      window.location.hostname === "127.0.0.1";
+
+    const baseURL = isLocalhost ? "https://pokeapi.co/api/v2" : "/api-pokemon";
+
+    const url = `${baseURL}/pokemon?limit=386&offset=0`;
     const response = await fetch(url);
     const data = await response.json();
     arrPokemons = data.results;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/api-pokemon/:path*",
+      "destination": "https://pokeapi.co/api/v2/:path*"
+    }
+  ]
+}


### PR DESCRIPTION
- Implementa rewrite em vercel.json para contornar restrições de CORS
- Ajusta fetch para usar proxy em produção e acesso direto em localhost
- Limita a busca para 386 Pokémon (Kanto, Johto e Hoenn)
- Melhora a estabilidade da aplicação em ambientes públicos